### PR TITLE
Adding support for different encodings to SimpleMLLPClient

### DIFF
--- a/Base/Net/SimpleMLLPClient.cs
+++ b/Base/Net/SimpleMLLPClient.cs
@@ -129,37 +129,6 @@ namespace NHapiTools.Base.Net
         }
 
         /// <summary>
-        /// Send a HL7 message
-        /// </summary>
-        /// <param name="message">Message to send</param>
-        /// <param name="encoding"></param>
-        /// <returns>Reply message</returns>
-        public string SendHL7Message(string message, Encoding encoding)
-        {
-            message = MLLP.CreateMLLPMessage(message);
-
-            // Send the message
-            StreamWriter sw = new StreamWriter(streamToUse);
-            sw.Write(encoding.GetBytes(message));
-            sw.Flush();
-
-            // Read the reply
-            StringBuilder sb = new StringBuilder();
-            bool messageComplete = false;
-            while (!messageComplete)
-            {
-                int b = streamToUse.ReadByte();
-                if (b != -1)
-                    sb.Append((char)b);
-
-                messageComplete = MLLP.ValidateMLLPMessage(sb);
-            }
-            MLLP.StripMLLPContainer(sb);
-
-            return sb.ToString();
-        }
-
-        /// <summary>
         /// Disconnect from the server
         /// </summary>
         public void Disconnect()

--- a/Base/Net/SimpleMLLPClient.cs
+++ b/Base/Net/SimpleMLLPClient.cs
@@ -48,7 +48,7 @@ namespace NHapiTools.Base.Net
         /// </summary>
         /// <param name="hostname">Hostname to connect to.</param>
         /// <param name="port">Port</param>
-        /// <param name="encoding">Ecoding of the byte stream (Default utf-8)</param>
+        /// <param name="encoding">Encoding of the byte stream (Default utf-8)</param>
         public SimpleMLLPClient(string hostname, int port, Encoding encoding)
             : this(hostname, port)
         {

--- a/Base/Net/SimpleMLLPClient.cs
+++ b/Base/Net/SimpleMLLPClient.cs
@@ -48,6 +48,7 @@ namespace NHapiTools.Base.Net
         /// </summary>
         /// <param name="hostname">Hostname to connect to.</param>
         /// <param name="port">Port</param>
+        /// <param name="encoding">Ecoding of the byte stream (Default utf-8)</param>
         public SimpleMLLPClient(string hostname, int port, Encoding encoding)
             : this(hostname, port)
         {


### PR DESCRIPTION
With this addition, the client could sends the byte stream in the user defined encoding. So e.g. if the default encoding of the server is ISO 8859-1, you could define that in the constructor parameter "encoding".