### PR TITLE
NHapiTools V251 to V281 are surprisingly targeting the .NET 4.5.2

### DIFF
--- a/Base/Util/Ack.cs
+++ b/Base/Util/Ack.cs
@@ -70,6 +70,10 @@ namespace NHapiTools.Base.Util
         /// <returns>Created ACK message</returns>
         public IMessage MakeACK(IMessage inboundMessage, AckTypes ackResult, string errorMessage)
         {
+            //this should avoid an unhandled null reference exception in "inboundMessage.Version", because people tend to send the inboudMessage without a check
+            if (inboundMessage == null)
+                throw new ArgumentNullException("Either process the valid message while retreiving the ack or handle invalid message differently");
+                
             IMessage ackMessage = null;
             // Get an object from the right ACK class
             string ackClassType = string.Format("NHapi.Model.V{0}.Message.ACK, NHapi.Model.V{0}", inboundMessage.Version.Replace(".", ""));

--- a/Model.V26/NHapiTools.Model.V26.csproj
+++ b/Model.V26/NHapiTools.Model.V26.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHapiTools.Model.V26</RootNamespace>
     <AssemblyName>NHapiTools.Model.V26</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Model.V26/packages.config
+++ b/Model.V26/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nHapi" version="2.5.0.6" targetFramework="net452" />
+  <package id="nHapi" version="2.5.0.6" targetFramework="net45" />
 </packages>

--- a/Model.V27/NHapiTools.Model.V27.csproj
+++ b/Model.V27/NHapiTools.Model.V27.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHapiTools.Model.V27</RootNamespace>
     <AssemblyName>NHapiTools.Model.V27</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Model.V27/packages.config
+++ b/Model.V27/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nHapi" version="2.5.0.6" targetFramework="net452" />
+  <package id="nHapi" version="2.5.0.6" targetFramework="net45" />
 </packages>

--- a/Model.V271/NHapiTools.Model.V271.csproj
+++ b/Model.V271/NHapiTools.Model.V271.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHapiTools.Model.V271</RootNamespace>
     <AssemblyName>NHapiTools.Model.V271</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Model.V271/packages.config
+++ b/Model.V271/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nHapi" version="2.5.0.6" targetFramework="net452" />
+  <package id="nHapi" version="2.5.0.6" targetFramework="net45" />
 </packages>

--- a/Model.V28/NHapiTools.Model.V28.csproj
+++ b/Model.V28/NHapiTools.Model.V28.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHapiTools.Model.V28</RootNamespace>
     <AssemblyName>NHapiTools.Model.V28</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Model.V28/packages.config
+++ b/Model.V28/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nHapi" version="2.5.0.6" targetFramework="net452" />
+  <package id="nHapi" version="2.5.0.6" targetFramework="net45" />
 </packages>

--- a/Model.V281/NHapiTools.Model.V281.csproj
+++ b/Model.V281/NHapiTools.Model.V281.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NHapiTools.Model.V281</RootNamespace>
     <AssemblyName>NHapiTools.Model.V281</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Model.V281/packages.config
+++ b/Model.V281/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nHapi" version="2.5.0.6" targetFramework="net452" />
+  <package id="nHapi" version="2.5.0.6" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hi Bas, 

thank you for this useful project, I recently ran into a compatibility issue while deploying the` .NET 4.5` project that references the lasted release of `NHapiTools.` 

Is there any particular reason you decided to target the `.NET 4.5.2` for the above projects? the `README.MD `is still mentioning that the project targets the `.NET 4.5.`

 I will be pleased if you could accept the pull request to go back to 4.5 for there projects. 

Thanks 

Oliamster

