### PR TITLE
Fixes ActivateObject method in ConfigurableContext - netstandard2.0 only.

### DIFF
--- a/Base/Validation/ConfigurableContext.cs
+++ b/Base/Validation/ConfigurableContext.cs
@@ -70,7 +70,15 @@ namespace NHapiTools.Base.Validation
         {
         #if NETSTANDARD2_0
             var loadedAssembly = Assembly.Load(assembly);
-            var type = loadedAssembly.GetTypes().SingleOrDefault(t => !t.IsAbstract && !t.IsInterface && t.IsClass && t.Name == classType);
+            var type =
+                loadedAssembly.GetTypes()
+                    .SingleOrDefault(
+                        t => !t.IsAbstract && !t.IsInterface && t.IsClass && t.FullName == classType.Trim());
+
+            if (type == null)
+            {
+                throw new ArgumentException($"Could not find classType: {classType} in Assembly: {assembly}");
+            }
 
             var instance = Activator.CreateInstance(type);
             return instance as T;

--- a/NuGet/NHapiTools.nuspec
+++ b/NuGet/NHapiTools.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>NHapiTools</id>
-    <version>1.11.0.0</version>
+    <version>1.11.0.1</version>
     <authors>Division by Zero</authors>
     <owners>Division by Zero</owners>
     <license type="file">LICENSE</license>

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -42,10 +42,8 @@ namespace TestApp
             _parsedMessages = new List<IMessage>();
 
             TestSourceGenerator();
-            // HL7InputStreamMessageStringEnumerator is possibly broken throws DirectoryNotFoundException "Could not find part of the path." or the test is broken?
-            //TestHl7FileStream();
-            // HL7InputStreamMessageStringEnumerator is possibly broken throws DirectoryNotFoundException "Could not find part of the path." or the test is broken?
-            //TestHl7FileMessageStream();
+            TestHl7FileStream();
+            TestHl7FileMessageStream();
             TestParserAutomatedContext();
             TestParserConfigurableContext();
             TestGenericMessageWrapper();
@@ -499,6 +497,7 @@ namespace TestApp
         private static void mfs_FileCompleted(object sender, FileCompletedEventArgs e)
         {
             var path = _basePath + "\\TestApp\\TestMessages\\Done";
+            Directory.CreateDirectory(path);
 
             var fi = new FileInfo(e.FileName);
             fi.MoveTo(path + "\\" + fi.Name);


### PR DESCRIPTION
`SingleOrDefault` to use `FullName` instead of `Name` when looking for type, also trim the `classType` parameter as sometimes the value had whitespace at the front.

```c#
#if NETSTANDARD2_0
    var loadedAssembly = Assembly.Load(assembly);
    var type =
        loadedAssembly.GetTypes()
            .SingleOrDefault(
                t => !t.IsAbstract && !t.IsInterface && t.IsClass && t.FullName == classType.Trim());

    if (type == null)
    {
        throw new ArgumentException($"Could not find classType: {classType} in Assembly: {assembly}");
    }

    var instance = Activator.CreateInstance(type);
    return instance as T;
#elif NET45
...
```

also fixes `mfs_FileCompleted` event handler which would blow-up if the output directory didn't exist.

```c#
var path = _basePath + "\\TestApp\\TestMessages\\Done";
Directory.CreateDirectory(path);
...
```
This fixed the following 2 `TestApp` methods `TestHl7FileStream()`, `TestHl7FileMessageStream()`.