### PR TITLE
Ack.cs: Fix MSH-7 timestamp. Had mm / hh(HH) mixed

### DIFF
--- a/src/Base/Util/Ack.cs
+++ b/src/Base/Util/Ack.cs
@@ -121,7 +121,7 @@ namespace NHapiTools.Base.Util
             terser.Set("/MSH-4", environmentIdentifier);
             terser.Set("/MSH-5", sendingApp);
             terser.Set("/MSH-6", sendingEnv);
-            terser.Set("/MSH-7", DateTime.Now.ToString("yyyyMMddmmhh"));
+            terser.Set("/MSH-7", DateTime.Now.ToString("yyyyMMddHHmm"));
             terser.Set("/MSH-9", "ACK");
             terser.Set("/MSH-12", version);
             terser.Set("/MSA-1", Enum.GetName(typeof(AckTypes), ackResult));


### PR DESCRIPTION
According to spec, this MSH-7 field should have yyyyMMddHHmm formatting

EG if today is 30th October 2020, at 11:25am, then it should be 202010301125

With the old format string it was incorrect, using 202010302511.  

A generated ACK failed a conformance test due to there being no 25th hour in the day.

Do you want some tests around this too?