### PR TITLE
Ensure client does not block perpetually when no response received

### DIFF
--- a/src/Base/Net/SimpleMLLPClient.cs
+++ b/src/Base/Net/SimpleMLLPClient.cs
@@ -31,11 +31,15 @@ namespace NHapiTools.Base.Net
         /// </summary>
         /// <param name="hostname">Hostname to connect to.</param>
         /// <param name="port">Port</param>
-        public SimpleMLLPClient(string hostname, int port)
+        /// <param name="receiveTimeout">Timeout (in milliseconds) used when receiving a response from the recipient</param>
+        public SimpleMLLPClient(string hostname, int port, int receiveTimeout = 30000)
         {
             serverHostname = hostname;
             cCollection = new X509CertificateCollection();
-            tcpClient = new TcpClient(hostname, port);
+            tcpClient = new TcpClient(hostname, port)
+            {
+                ReceiveTimeout = receiveTimeout
+            };
             clientStream = tcpClient.GetStream();
             streamToUse = clientStream;
         }
@@ -46,8 +50,9 @@ namespace NHapiTools.Base.Net
         /// <param name="hostname">Hostname to connect to.</param>
         /// <param name="port">Port</param>
         /// <param name="encoding">Encoding of the byte stream (Default utf-8)</param>
-        public SimpleMLLPClient(string hostname, int port, Encoding encoding)
-            : this(hostname, port)
+        /// <param name="receiveTimeout">Timeout (in milliseconds) used when receiving a response from the recipient</param>
+        public SimpleMLLPClient(string hostname, int port, Encoding encoding, int receiveTimeout = 30000)
+            : this(hostname, port, receiveTimeout)
         {
             encodingForStream = encoding;            
         }


### PR DESCRIPTION
Adds a timeout on the read operation of the stream when sending a message to a recipient. This ensures that the SimpleMLLPClient does not wait perpetually if the recipient never responds. Currently, if the recipient does not respond with an ACK it will block on the stream.ReadByte() call. With this change, a SocketException will be thrown after the timeout (default 30 second) elapses. 