### PR TITLE
Check for null encodingForStream

### DIFF
--- a/src/Base/Net/SimpleMLLPClient.cs
+++ b/src/Base/Net/SimpleMLLPClient.cs
@@ -113,7 +113,7 @@ namespace NHapiTools.Base.Net
             message = MLLP.CreateMLLPMessage(message);
 
             // Send the message
-            StreamWriter sw = new StreamWriter(streamToUse, encodingForStream);
+            StreamWriter sw = encodingForStream == null ?  new StreamWriter(streamToUse) : new StreamWriter(streamToUse, encodingForStream);
             sw.Write(message);
             sw.Flush();
 


### PR DESCRIPTION
new StreamWriter(Stream, Encoding) throws NullReferenceException if the encoding parameter is given but null. Withouth this parameter, it defaults to UTF-8.