### PR TITLE
Fixed a small bug in case the server responds with UT8 responses.

### DIFF
--- a/src/Base/Net/SimpleMLLPClient.cs
+++ b/src/Base/Net/SimpleMLLPClient.cs
@@ -141,7 +141,7 @@ namespace NHapiTools.Base.Net
                 if (!messageComplete && DateTime.Now.Subtract(startReadingTime).TotalMilliseconds > timeout)
                     throw new TimeoutException($"Reading the HL7 reply timed out after {timeout} milliseconds.");
             }
-            byte[] messageBytes = buffer.Skip(1).Take(buffer.Count - 3).ToArray();
+            byte[] messageBytes = MLLP.StripMLLPContainer(buffer);
             return (encodingForStream ?? Encoding.UTF8).GetString(messageBytes);
         }
 

--- a/src/Base/Net/SimpleMLLPClient.cs
+++ b/src/Base/Net/SimpleMLLPClient.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Net.Sockets;
 using System.Net.Security;
@@ -118,6 +120,7 @@ namespace NHapiTools.Base.Net
             sw.Flush();
 
             // Read the reply
+            List<byte> buffer = new List<byte>();
             StringBuilder sb = new StringBuilder();
             bool messageComplete = false;
             DateTime startReadingTime = DateTime.Now;
@@ -125,7 +128,10 @@ namespace NHapiTools.Base.Net
             {
                 int b = streamToUse.ReadByte();
                 if (b != -1)
-                    sb.Append((char) b);
+                {
+                    buffer.Add((byte)b);
+                    sb.Append((char)b);
+                }
 
                 messageComplete = MLLP.ValidateMLLPMessage(sb);
 
@@ -135,9 +141,8 @@ namespace NHapiTools.Base.Net
                 if (!messageComplete && DateTime.Now.Subtract(startReadingTime).TotalMilliseconds > timeout)
                     throw new TimeoutException($"Reading the HL7 reply timed out after {timeout} milliseconds.");
             }
-            MLLP.StripMLLPContainer(sb);
-
-            return sb.ToString();
+            byte[] messageBytes = buffer.Skip(1).Take(buffer.Count - 3).ToArray();
+            return (encodingForStream ?? Encoding.UTF8).GetString(messageBytes);
         }
 
         /// <summary>

--- a/src/Base/Util/MLLP.cs
+++ b/src/Base/Util/MLLP.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
+using System.Linq;
 
 namespace NHapiTools.Base.Util
 {
@@ -23,6 +25,12 @@ namespace NHapiTools.Base.Util
             // Strip the message of the MLLP container characters
             sb.Remove(0, 1);
             sb.Remove(sb.Length - 2, 2);
+        }
+        
+        public static byte[] StripMLLPContainer(List<byte> bytes)
+        {
+            // Strip the message of the MLLP container characters
+            return bytes.Skip(1).Take(bytes.Count - 3).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
I did not change the ValidateMLLPMessage based on the stringbuilder but this can also be done on the byte array thus removing the need for the stringbuilder altogether.
This code also assumes if you instantiate the client with an encoding that the server will answer in the same encoding, if none provided UTF-8 is assumed.